### PR TITLE
Fix default search path to also check apache-cimprov's libdir

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -144,7 +144,7 @@ endif
 
 COMPILE_FLAGS := $(PROV_DEBUG_FLAGS) -D_REENTRANT -fstack-protector-all -Wall -fno-nonansi-builtins  -Woverloaded-virtual -Wformat -Wformat-security -Wcast-align -Wswitch-enum -Wshadow -Wwrite-strings -Wredundant-decls -Werror -Wno-cast-qual -fPIC
 
-LINK_LIBRARIES := -Wl,-rpath=/opt/omi/lib -L$(OMI_ROOT)/output/lib $(APACHE_SOURCE_LIB_PATH_OPTION) -lmicxx -lapr-1
+LINK_LIBRARIES := -Wl,-rpath=/opt/microsoft/apache-cimprov/lib -Wl,-rpath=/opt/omi/lib -L$(OMI_ROOT)/output/lib $(APACHE_SOURCE_LIB_PATH_OPTION) -lmicxx -lapr-1
 PROVIDER_TEST_LINK_LIBRARIES := -lbase -lpal -L$(SCXPAL_TARGET_DIR) -lscxcore $(SCXPAL_DIR)/test/ext/lib/linux/$(ARCH)/cppunit/libcppunit.a -lpthread -lrt
 
 SHARED_FLAGS := -shared


### PR DESCRIPTION
@Microsoft/ostc-devs 
@OpusDude 
