### PR TITLE
Apache's CustomLog paramater can take a third optional parameter

### DIFF
--- a/source/code/module/mod_cimprov.c
+++ b/source/code/module/mod_cimprov.c
@@ -445,7 +445,7 @@ static const command_rec cimprov_module_cmds[] =
     AP_INIT_RAW_ARGS("ServerAlias", set_server_alias, NULL, RSRC_CONF,
       "A name or names alternately used to access the server"),
     AP_INIT_TAKE1("SSLCertificateFile", set_server_certificate_file, NULL, RSRC_CONF,
-      "Set the name of the SSL certificate file for the host."),
+      "SSL Server Certificate file ('/path/to/file' - PEM or DER encoded)"),
     {NULL}
 };
 


### PR DESCRIPTION
@Microsoft/ostc-devs 

Apache's CustomLog parameter can take a third optional parameter.

Checked all of other configuration parameters we look at, all others are consistent with Apache usage. Fixed SSLCertificateFile description to be consistent with how SSL module defines it to be.
