### PR TITLE
Apache 500 errors aren't detected by Linux oms agents

### DIFF
--- a/source/code/providers/support/datasampler.cpp
+++ b/source/code/providers/support/datasampler.cpp
@@ -559,8 +559,8 @@ void DataSampler::PerformComputations()
         apr_atomic_set32(&vhosts[i].kbPerSecond, (deltaBytes / 1024) / apr_time_sec(deltaTime));
 
         // errorsPerMinute* = (errorDelta / (# of seconds since last run)) * 60. (the idea is to normalize to a per-minute rate)
-        apr_atomic_set32(&vhosts[i].errorsPerMinute400, (delta400 / apr_time_sec(deltaTime)) * 60);
-        apr_atomic_set32(&vhosts[i].errorsPerMinute500, (delta500 / apr_time_sec(deltaTime)) * 60);
+        apr_atomic_set32(&vhosts[i].errorsPerMinute400, ((delta400 * 60) / apr_time_sec(deltaTime)));
+        apr_atomic_set32(&vhosts[i].errorsPerMinute500, ((delta500 * 60) / apr_time_sec(deltaTime)));
     }
 
     // TODO: Unlock the process mutex


### PR DESCRIPTION
The 500 or 400 Errrors Per Minutes calculation logic has the issue. Here is the logic used for this calculation.

            (delta500 / apr_time_sec(deltaTime)) * 60

Here delta400 and delta500 is declared as apr_uint32_t. 

When Apache server generates 500/400 error in every second, 
delta500=1 and deltaTime=1 and it becomes (1/1)*60=60 which is the expected value.

But when Apache server generates 500 error in every 3 seconds 
The delta500=1 and deltaTime=3 and it is evaluated to (1/3)*60=0.